### PR TITLE
Add AI automation toggle

### DIFF
--- a/src/components/ChatView.css
+++ b/src/components/ChatView.css
@@ -11,6 +11,13 @@
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
+.chat-header {
+    padding: 10px;
+    border-bottom: 1px solid #ccc;
+    display: flex;
+    justify-content: flex-end;
+}
+
 .chat-messages {
     flex-grow: 1;
     overflow-y: auto;

--- a/src/components/ChatView.jsx
+++ b/src/components/ChatView.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { supabase } from '../supabaseClient'; // Importa o cliente Supabase
+import ToggleSwitch from './ToggleSwitch';
 import './ChatView.css';
+import './ToggleSwitch.css';
 
 // Componente para uma única bolha de mensagem (nenhuma alteração aqui)
 const ChatMessage = ({ message }) => (
@@ -18,7 +20,27 @@ const ChatMessage = ({ message }) => (
 const ChatView = ({ patientPhone, clinicId }) => {
     const [messages, setMessages] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [isAiActive, setIsAiActive] = useState(false);
     const messagesEndRef = useRef(null);
+
+    const handleToggleAutomation = async () => {
+        try {
+            const response = await fetch(
+                `${import.meta.env.VITE_BACKEND_API_URL}/api/v1/patients/${patientPhone}/toggle-automation`,
+                { method: 'PATCH' }
+            );
+            if (!response.ok) {
+                console.error('Erro ao alternar automação');
+                return;
+            }
+            const data = await response.json();
+            if (typeof data.is_ai_active === 'boolean') {
+                setIsAiActive(data.is_ai_active);
+            }
+        } catch (err) {
+            console.error('Erro ao enviar requisição:', err);
+        }
+    };
 
     // Efeito para rolar para a última mensagem
     useEffect(() => {
@@ -42,6 +64,19 @@ const ChatView = ({ patientPhone, clinicId }) => {
             } else {
                 setMessages(data);
             }
+
+            const { data: patientData, error: patientError } = await supabase
+                .from('patients')
+                .select('is_ai_active')
+                .eq('phone', patientPhone)
+                .single();
+
+            if (patientError) {
+                console.error('Erro ao buscar paciente:', patientError);
+            } else if (patientData) {
+                setIsAiActive(patientData.is_ai_active);
+            }
+
             setLoading(false);
         };
 
@@ -91,6 +126,9 @@ const ChatView = ({ patientPhone, clinicId }) => {
 
     return (
         <div className="chat-container">
+            <div className="chat-header">
+                <ToggleSwitch checked={isAiActive} onChange={handleToggleAutomation} />
+            </div>
             <div className="chat-messages">
                 {messages.map(msg => (
                     <ChatMessage key={msg.id} message={msg} />

--- a/src/components/ToggleSwitch.css
+++ b/src/components/ToggleSwitch.css
@@ -1,0 +1,44 @@
+.toggle-switch {
+  position: relative;
+  width: 42px;
+  height: 24px;
+  display: inline-block;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: 0.4s;
+  border-radius: 24px;
+}
+
+.toggle-slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  transition: 0.4s;
+  border-radius: 50%;
+}
+
+.toggle-switch input:checked + .toggle-slider {
+  background-color: #4caf50;
+}
+
+.toggle-switch input:checked + .toggle-slider:before {
+  transform: translateX(18px);
+}

--- a/src/components/ToggleSwitch.jsx
+++ b/src/components/ToggleSwitch.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import './ToggleSwitch.css';
+
+function ToggleSwitch({ checked, onChange }) {
+  return (
+    <label className="toggle-switch">
+      <input type="checkbox" checked={checked} onChange={onChange} />
+      <span className="toggle-slider" />
+    </label>
+  );
+}
+
+export default ToggleSwitch;


### PR DESCRIPTION
## Summary
- style header for chat view and new toggle switch component
- implement `ToggleSwitch` component
- load patient's automation status and add button to toggle automation

## Testing
- `npm run lint` *(fails: cannot find package @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68731bff26bc8321a658dcd497a4bcce