### PR TITLE
Add environment example file and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+VITE_SUPABASE_URL=your-supabase-url-here
+VITE_SUPABASE_ANON_KEY=your-supabase-anon-key-here
+VITE_BACKEND_API_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -10,3 +10,14 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Environment Variables
+
+Copy `.env.example` to `.env.local` and fill in the values for:
+
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
+- `VITE_BACKEND_API_URL`
+
+`.env.local` is ignored by git and will be used by Vite during development.
+


### PR DESCRIPTION
## Summary
- provide `.env.example` with placeholders for API environment variables
- document env setup in README

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6875538a12dc8321b488fe75491b5403