### PR TITLE
Improve responsive layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -122,3 +122,53 @@
   height: 100%;
   width: 100%;
 }
+
+/* Botão que exibe/oculta o menu em telas pequenas */
+.nav-toggle {
+  display: none;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  background: #f0f2f5;
+  border: 1px solid #d1d7db;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+@media (max-width: 768px) {
+  .nav-toggle {
+    display: block;
+    z-index: 1100;
+  }
+
+  .app-nav {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 1000;
+  }
+
+  .app-nav.open {
+    transform: translateX(0);
+  }
+
+  .crm-layout {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    max-width: none;
+    min-width: 0;
+    height: 40vh;
+  }
+
+  .chat-area {
+    flex: 1;
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,8 +8,9 @@ import './App.css'; // O CSS geral que contém o layout
 
 function App() {
   // Em uma aplicação real, o ID da clínica viria do login do usuário.
-  const [clinicId] = useState('dd6a92e1-6ab5-4411-b752-d7f55151f293'); 
+  const [clinicId] = useState('dd6a92e1-6ab5-4411-b752-d7f55151f293');
   const [selectedPatientPhone, setSelectedPatientPhone] = useState(null);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
   
   // Estado para controlar qual página está ativa: 'conversas' ou 'settings'
   const [currentPage, setCurrentPage] = useState('conversas'); 
@@ -55,17 +56,20 @@ function App() {
 
   return (
     <div className="app-container">
+      <button className="nav-toggle" onClick={() => setIsMenuOpen(!isMenuOpen)}>
+        ☰
+      </button>
       {/* MENU DE NAVEGAÇÃO LATERAL */}
-      <nav className="app-nav">
+      <nav className={`app-nav ${isMenuOpen ? 'open' : ''}`}> 
         <ul>
-          <li 
-            onClick={() => setCurrentPage('conversas')} 
+          <li
+            onClick={() => { setCurrentPage('conversas'); setIsMenuOpen(false); }}
             className={currentPage === 'conversas' ? 'active' : ''}
           >
             <span role="img" aria-label="Conversas">💬</span> Conversas
           </li>
-          <li 
-            onClick={() => setCurrentPage('settings')} 
+          <li
+            onClick={() => { setCurrentPage('settings'); setIsMenuOpen(false); }}
             className={currentPage === 'settings' ? 'active' : ''}
           >
             <span role="img" aria-label="Configurações">⚙️</span> Configurações

--- a/src/components/ChatView.css
+++ b/src/components/ChatView.css
@@ -230,3 +230,15 @@
 .skeleton-message-row-right { justify-content: flex-end; }
 .skeleton-bubble { width: 60%; height: 50px; border-radius: 8px; }
 .skeleton-bubble-short { width: 40%; height: 30px; border-radius: 8px; }
+
+@media (max-width: 768px) {
+  .chat-view-container {
+    flex-direction: column;
+  }
+
+  .summary-sidebar {
+    width: 100%;
+    border-left: none;
+    border-top: 1px solid #e0e0e0;
+  }
+}

--- a/src/components/ConversationList.css
+++ b/src/components/ConversationList.css
@@ -134,3 +134,9 @@
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+@media (max-width: 768px) {
+  .conversation-list {
+    height: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- add collapsible sidebar menu for small screens
- tweak CSS for responsive conversation view
- adjust chat view and sidebar for mobile layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6877e9f5c2f08321bded9d8774e6fd41